### PR TITLE
Rast Invalid JobID Fix

### DIFF
--- a/phagecommander/GuiWidgets/RastJobDialogue.py
+++ b/phagecommander/GuiWidgets/RastJobDialogue.py
@@ -86,10 +86,13 @@ class RastJobDialog(QDialog):
             client = RastPy.Rast(userInput, passInput, jobId=jobInput)
         except RastPy.RastInvalidCredentialError:
             QMessageBox.critical(self, 'Invalid Credentials', 'Invalid credentials. Check username and password.')
+            return
         except RastPy.RastInvalidJobError:
             QMessageBox.critical(self, 'Invalid JobID', 'Given JobID "{}" is not valid.'.format(jobInput))
+            return
         except Exception as e:
-            pass
+            QMessageBox.critical(self, 'Unexpected Error', 'Error: {}'.format(e))
+            return
 
         # creds and jobID at this point are valid, return values
         self.queryData.rastUser = userInput

--- a/phagecommander/GuiWidgets/RastJobDialogue.py
+++ b/phagecommander/GuiWidgets/RastJobDialogue.py
@@ -32,6 +32,7 @@ class RastJobDialog(QDialog):
         self.jobLineEdit = QLineEdit()
         jobLineEditText = 'OPTIONAL - Leave Blank for New Job '
         self.jobLineEdit.setPlaceholderText(jobLineEditText)
+        self.jobLineEdit.textEdited.connect(self.onJobLineEdit)
         # set width according to size of line edit placeholder text
         font = QFont()
         metric = QFontMetrics(font)
@@ -89,6 +90,7 @@ class RastJobDialog(QDialog):
             return
         except RastPy.RastInvalidJobError:
             QMessageBox.critical(self, 'Invalid JobID', 'Given JobID "{}" is not valid.'.format(jobInput))
+            self.jobLineEdit.setStyleSheet(self._INVALID_INPUT_BORDER)
             return
         except Exception as e:
             QMessageBox.critical(self, 'Unexpected Error', 'Error: {}'.format(e))
@@ -122,6 +124,13 @@ class RastJobDialog(QDialog):
         Slot when password line is edited
         """
         self.passwordLineEdit.setStyleSheet(self._DEFAULT_STYLE_SHEET)
+
+    @pyqtSlot()
+    def onJobLineEdit(self):
+        """
+        Slot when the jobID line is edited
+        """
+        self.jobLineEdit.setStyleSheet(self._DEFAULT_STYLE_SHEET)
 
 
 if __name__ == '__main__':

--- a/phagecommander/Utilities/RastPy.py
+++ b/phagecommander/Utilities/RastPy.py
@@ -7,6 +7,7 @@ from ruamel import yaml
 RAST_URL = 'https://pubseed.theseed.org/rast/server.cgi'
 RAST_USER_URL = 'https://rast.nmpdr.org/rast.cgi'
 
+
 class RastException(Exception):
     pass
 
@@ -125,7 +126,8 @@ class Rast:
         _CHECK_STATUS_FUNCTION = 'status_of_RAST_job'
         _ERROR_MSG_FIELD = 'error_msg'
         _ERROR_STATUS = 'error'
-        _INVALID_JOB_ID_MSG = 'Access denied'
+        _ACCESS_DENIED_ERROR = 'Access denied'
+        _INVALID_JOB_ID = 'Job not found'
 
         if self.jobId is None:
             return False
@@ -144,7 +146,7 @@ class Rast:
 
         # raise exception for invalid jobID
         if self.status == _ERROR_STATUS:
-            if statusContent[self.jobId][_ERROR_MSG_FIELD] == _INVALID_JOB_ID_MSG:
+            if statusContent[self.jobId][_ERROR_MSG_FIELD] == _ACCESS_DENIED_ERROR or _INVALID_JOB_ID:
                 raise RastInvalidJobError('Invalid JobID: {}'.format(self.jobId))
 
         return True if jobStatus == _SUCCESSFUL_STATUS else False
@@ -190,5 +192,5 @@ class Rast:
 
 
 if __name__ == '__main__':
-    rast = Rast('mlazeroff', 'chester', 822395)
+    rast = Rast('mlazeroff', 'chester', 1)
     print(rast.checkIfComplete())


### PR DESCRIPTION
Users are now notified when a given jobID is invalid and a new RAST job is not created.
